### PR TITLE
[FEAT] 경로 안내 카드에 거리 표시를 추가합니다.

### DIFF
--- a/src/components/navigate-card.tsx
+++ b/src/components/navigate-card.tsx
@@ -6,14 +6,14 @@ import { cn } from '~/utils/cn'
 function NavigateCard({
   index,
   type,
-  distance,
   description,
 }: {
   index: number
   type: keyof typeof NavigateType
-  distance?: number
   description: string
 }) {
+  const distance = description.match(/(\d+)m/g)
+
   return (
     <div className="relative flex w-[166px] shrink-0 flex-col overflow-hidden rounded bg-primary-500 shadow">
       <div className="absolute left-0.5 top-0.5 z-50 flex size-9 items-center justify-center rounded-full bg-gray-900">
@@ -38,7 +38,7 @@ function NavigateCard({
                   : 'text-primary-500',
               )}
             >
-              {distance}m
+              {distance[0].replace('m', '')}m
             </span>
           </div>
         )}


### PR DESCRIPTION
description에서 `[숫자]m` 텍스트를 정규식으로 필터링해서 카드에 표시합니다.
![CleanShot 2024-10-13 at 19 20 45@2x](https://github.com/user-attachments/assets/762a3f61-deb0-48bb-a55d-cb7c1d89127c)
